### PR TITLE
use `time.process_time()` instead of `time.clock()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Features
 
 Requirements
 ------------
-* [Python](http://python.org) 3.x (tested with 3.8.5)
+* [Python](http://python.org) 3.3 or later (tested with 3.11.3)
 * A NAND dump dumped by [BootMii](http://bootmii.org) and extracted by 
   [ShowMiiWads](http://code.google.com/p/showmiiwads) or [nandextract](http://github.com/Plombo/showmiiwads)
 * Additional requirements applies for some Neo Geo games, see [neogeo_reame.txt](neogeo_readme.txt)

--- a/lz77.py
+++ b/lz77.py
@@ -130,13 +130,13 @@ if __name__ == '__main__':
 	import time
 	f = open(sys.argv[1], 'rb')
 	
-	start = time.clock()
+	start = time.process_time()
 	if (sys.argv[2] == 'True'):
 		du = decompress_n64(f)
 	else:
 		du = decompress_nonN64(f)
 	
-	end = time.clock()
+	end = time.process_time()
 	print('Time: %.2f seconds' % (end - start))
 		
 	f2 = open(sys.argv[2], 'wb')

--- a/snesrestore.py
+++ b/snesrestore.py
@@ -121,9 +121,9 @@ if __name__ == '__main__':
 	
 	# encode and inject BRR sound data into the ROM
 	print('Encoding and restoring BRR audio data to ROM')
-	start = time.clock()
+	start = time.process_time()
 	string = restore_brr_samples(vcrom, pcm)
-	end = time.clock()
+	end = time.process_time()
 	print('Time: %.2f seconds' % (end - start))
 	
 	# write to file


### PR DESCRIPTION
`time.clock()` was removed in 3.8, and I had to change it in order to decompress an SNES rom from Kirby's Dream Collection

I have to change the min version to 3.3 as a result.